### PR TITLE
Use correct key for cache request

### DIFF
--- a/texengine.cpp
+++ b/texengine.cpp
@@ -68,7 +68,7 @@ QString TeXEngine::TeX2SVG ( QString TeXcode )
     while ( running )
         QCoreApplication::processEvents( QEventLoop::AllEvents, 20 );
     computeNextInBackground();
-    QString *ptr = cache[TeXcode];
+    QString *ptr = cache[currentInput];
     return ptr ? QString( ptr->constData() ) : QString();
 }
 


### PR DESCRIPTION
If `TeX2SVG()` is passed a string containing backslashes, it will return
`QString()` on first call, but correct result on all subsequent calls.
This happens because final cache request uses `TeXcode` as the key for
cache lookup; this is incorrect, since `TeXcode` is a modified version
of the input with all backslashes escaped.

The problem is easily solved by using `currentInput` as a key, which
always contains an unmodified version of the input.